### PR TITLE
Skip existing videos

### DIFF
--- a/lld.py
+++ b/lld.py
@@ -144,6 +144,11 @@ class Lld:
                     video_name = self.format_string(video['title'])
                     video_slug = video['slug']
                     video_data = (self.session.get(video_api_url % (course, video_slug)))
+                    video_path = chapter_path + '/' + '%s - %s.mp4' % (str(video_index).zfill(2), video_name);
+                    if os.path.exists(video_path):
+                        logging.info('Skip video [%s] download because it already exists.' % video_name)
+                        video_index += 1
+                        continue
                     try:
                         video_url = re.search('"progressiveUrl":"(.+)","streamingUrl"', video_data.text).group(1)
                     except:


### PR DESCRIPTION
I have the problem that the script suddenly stops downloading videos and leaving me with this message:
```

^CTraceback (most recent call last):
  File "lld.py", line 191, in <module>
    main()
  File "lld.py", line 187, in main
    lld.download_courses()
  File "lld.py", line 157, in download_courses
    self.download_file(video_url, chapter_path, '%s - %s.mp4' % (str(video_index).zfill(2), video_name))
  File "lld.py", line 73, in download_file
    for chunk in resp.iter_content(chunk_size=1024):
  File "/home/adam/.local/lib/python2.7/site-packages/requests/models.py", line 750, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/home/adam/.local/lib/python2.7/site-packages/urllib3/response.py", line 494, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/home/adam/.local/lib/python2.7/site-packages/urllib3/response.py", line 442, in read
    data = self._fp.read(amt)
  File "/usr/lib/python2.7/httplib.py", line 597, in read
    s = self.fp.read(amt)
  File "/usr/lib/python2.7/socket.py", line 384, in read
    data = self._sock.recv(left)
  File "/usr/lib/python2.7/ssl.py", line 772, in recv
    return self.read(buflen)
  File "/usr/lib/python2.7/ssl.py", line 659, in read
    v = self._sslobj.read(len)
KeyboardInterrupt

```


So I have to restart the program. In order to avoid double downloads I recommend checking if path exists and then skipping the download